### PR TITLE
PEP 440 version pattern conform

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_mfa_cscs
-version = "v2023.1002"
+version = v2023.1002
 description = Enable multi-factor authentication for CSCS.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -57,4 +57,4 @@ start.py =
     __version__ = "{version}"
 setup.cfg =
     current_version = "{version}"
-    version = "{version}"
+    version = {version}


### PR DESCRIPTION
fixes #13 

If the version string is put under the double quotes, the version read from pip is `-v2023.1001-` which is not conform with PEP 440 and the installation will fail. 
This issue was not catched because it raise a warning and `pip == 23.1` will enforce the change to use  the legacy 'setup.py install' method, because a wheel could not be built for it. It is deprecated by https://github.com/pypa/pip/issues/8368 and thus in our new docker-stack which `pip==23.3.1` the exception manifest itself.